### PR TITLE
Fix: Optimize Dockerfile permissions to remove chown -R



### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,18 +43,17 @@ FROM base AS release
 
 ENV NODE_ENV production
 
-COPY --from=install /temp/prod/node_modules node_modules
-COPY --from=prerelease /usr/src/app/build build
-COPY --from=prerelease /usr/src/app/.strapi .strapi
-COPY --from=prerelease /usr/src/app/config config
-COPY --from=prerelease /usr/src/app/public public
-COPY --from=prerelease /usr/src/app/src src
-COPY --from=prerelease /usr/src/app/types types
-COPY --from=prerelease /usr/src/app/favicon.ico .
-COPY --from=prerelease /usr/src/app/package.json .
+COPY --chown=node:node --from=install /temp/prod/node_modules node_modules
+COPY --chown=node:node --from=prerelease /usr/src/app/build build
+COPY --chown=node:node --from=prerelease /usr/src/app/.strapi .strapi
+COPY --chown=node:node --from=prerelease /usr/src/app/config config
+COPY --chown=node:node --from=prerelease /usr/src/app/public public
+COPY --chown=node:node --from=prerelease /usr/src/app/src src
+COPY --chown=node:node --from=prerelease /usr/src/app/types types
+COPY --chown=node:node --from=prerelease /usr/src/app/favicon.ico .
+COPY --chown=node:node --from=prerelease /usr/src/app/package.json .
 
 # run the app
-RUN chown -R node:node /usr/src/app
 USER node
 
 EXPOSE 1337/tcp


### PR DESCRIPTION
I replaced the time-consuming `RUN chown -R node:node /usr/src/app`
command with the `--chown=node:node` flag in the `COPY` directives
within the final `release` stage.

This ensures that all files and directories copied into the application
directory (`/usr/src/app`) are owned by the `node` user and group from
the outset. The `USER node` directive then executes the application with
the correct ownership, eliminating the need for a separate `chown -R`
step and speeding up the Docker build process.